### PR TITLE
fix: change the achives format to tgz

### DIFF
--- a/.config/goreleaser.yaml
+++ b/.config/goreleaser.yaml
@@ -41,7 +41,7 @@ builds:
       - -extldflags '-static'
 
 archives:
-  - formats: [tar.gz]
+  - formats: [tgz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_


### PR DESCRIPTION
Fix #15 

Don't know why Goreleaser use `tgz` extension instead of `tar.gz`, so this fix is setting the format to `tgz` in order to have uniformity